### PR TITLE
Making version constraints more flexible in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "symfony/symfony": ">=2.1",
-        "stof/doctrine-extensions-bundle": "dev-master",
-        "sonata-project/admin-bundle": "dev-master",
-        "sonata-project/doctrine-orm-admin-bundle": "dev-master"
+        "symfony/symfony": "~2.1",
+        "stof/doctrine-extensions-bundle": "~1.0",
+        "sonata-project/admin-bundle": "~2.0",
+        "sonata-project/doctrine-orm-admin-bundle": "~2.0"
     },
     "suggest": {
         "liip/functional-test-bundle": "functional testing bundle",


### PR DESCRIPTION
Depending on dev-master versions of external bundles makes the bundle less flexible to be used with other bundles.
This change leaves a lot of space for older versions as well as latest versions.
